### PR TITLE
feat: [PIPE-20693]: Refactor task executable config structs

### DIFF
--- a/task/drivers/cgi/driver.go
+++ b/task/drivers/cgi/driver.go
@@ -21,12 +21,12 @@ var (
 
 // Config provides the driver config.
 type Config struct {
-	Executable *task.Executable  `json:"executable"`
-	Repository *task.Repository  `json:"repository"`
-	Method     string            `json:"method"`
-	Endpoint   string            `json:"endpoint"`
-	Headers    map[string]string `json:"headers"`
-	Envs       []string          `json:"envs"`
+	ExecutableConfig *task.ExecutableConfig `json:"executable_config"`
+	Repository       *task.Repository       `json:"repository"`
+	Method           string                 `json:"method"`
+	Endpoint         string                 `json:"endpoint"`
+	Headers          map[string]string      `json:"headers"`
+	Envs             []string               `json:"envs"`
 }
 
 // New returns the task execution driver.
@@ -51,7 +51,7 @@ func (d *driver) Handle(ctx context.Context, req *task.Request) task.Response {
 		return task.Error(err)
 	}
 
-	path, err := d.downloader.Download(ctx, req.Task.Type, conf.Repository, conf.Executable)
+	path, err := d.downloader.Download(ctx, req.Task.Type, conf.Repository, conf.ExecutableConfig)
 	if err != nil {
 		log.With("error", err).Error("artifact download failed")
 		return task.Error(err)
@@ -66,7 +66,7 @@ func (d *driver) Handle(ctx context.Context, req *task.Request) task.Response {
 	}
 
 	var binpath string
-	if conf.Executable != nil {
+	if conf.ExecutableConfig != nil {
 		// if an executable is downloaded directly via url, no need to use `builder`
 		binpath = path
 	} else {

--- a/task/types.go
+++ b/task/types.go
@@ -63,11 +63,21 @@ type Repository struct {
 	Download string `json:"download"`
 }
 
-// Executable provides the details to download
-// a custom binary task executable file
+// ExecutableConfig provides the details to download
+// a custom binary task executable file, for all
+// supported operating systems and architectures
+type ExecutableConfig struct {
+	Executables []Executable `json:"executables"`
+	Version     string       `json:"version"`
+}
+
+// Executable provides the url to download
+// a custom binary task executable file,
+// given the operating system and architecture
 type Executable struct {
-	Urls    map[string]string `json:"urls"`
-	Version string            `json:"version"`
+	Arch string `json:"arch"`
+	Os   string `json:"os"`
+	Url  string `json:"url"`
 }
 
 // Secret stores the value of a secret variable.


### PR DESCRIPTION
This PR is just as small refactor on the way we pass custom executable file URLs for a given task's execution.
This change was specifically requested here: https://github.com/harness/runner/pull/21#discussion_r1742789063

Previously, we had an `Executable` object that contained a map of `"os"/"arch"` to the URL. Now we have:

```
type ExecutableConfig struct {
	Executables []Executable `json:"executables"`
	Version     string       `json:"version"`
}

type Executable struct {
	Arch string `json:"arch"`
	Os   string `json:"os"`
	Url  string `json:"url"`
}
```
So that `ExecutableConfig` contains a list of `Executable` structs.