### PR TITLE
do not download repo when executable config is specified

### DIFF
--- a/task/drivers/cgi/driver.go
+++ b/task/drivers/cgi/driver.go
@@ -41,49 +41,30 @@ type driver struct {
 
 // Handle handles the task execution request.
 func (d *driver) Handle(ctx context.Context, req *task.Request) task.Response {
-	var (
-		log  = logger.FromContext(ctx)
-		conf = new(Config)
-	)
+	log := logger.FromContext(ctx)
 
+	conf := new(Config)
 	// decode the task configuration
 	err := json.Unmarshal(req.Task.Config, conf)
 	if err != nil {
 		return task.Error(err)
 	}
 
-	var path string
-	if conf.ExecutableConfig != nil {
-		path, err = d.downloader.DownloadExecutable(ctx, req.Task.Type, conf.Version, conf.ExecutableConfig)
-	} else {
-		path, err = d.downloader.DownloadRepo(ctx, conf.Repository)
-	}
-
+	path, err := d.downloadArtifact(ctx, req.Task.Type, conf)
 	if err != nil {
 		log.With("error", err).Error("artifact download failed")
 		return task.Error(err)
 	}
 
-	if conf.Method == "" {
-		conf.Method = "POST"
+	setDefaultConfigValues(conf)
+
+	binPath, err := d.getBinaryPath(ctx, path, conf)
+	if err != nil {
+		log.With("error", err).Error("task build failed")
+		return task.Error(err)
 	}
 
-	if conf.Endpoint == "" {
-		conf.Endpoint = "/"
-	}
-
-	var binpath string
-	if conf.ExecutableConfig != nil {
-		// if an executable is downloaded directly via url, no need to use `builder`
-		binpath = path
-	} else {
-		builder := builder.New(filepath.Join(path, taskYmlPath))
-		binpath, err = builder.Build(ctx)
-		if err != nil {
-			log.With("error", err).Error("task build failed")
-		}
-	}
-	execer := newExecer(binpath, conf)
+	execer := newExecer(binPath, conf)
 	resp, err := execer.Exec(ctx, req.Task.Data)
 	if err != nil {
 		log.With("error", err).Error("could not execute cgi task")
@@ -91,4 +72,29 @@ func (d *driver) Handle(ctx context.Context, req *task.Request) task.Response {
 	}
 
 	return task.Respond(resp)
+}
+
+func (d *driver) downloadArtifact(ctx context.Context, taskType string, conf *Config) (string, error) {
+	if conf.ExecutableConfig != nil {
+		return d.downloader.DownloadExecutable(ctx, taskType, conf.Version, conf.ExecutableConfig)
+	}
+	return d.downloader.DownloadRepo(ctx, conf.Repository)
+}
+
+func setDefaultConfigValues(conf *Config) {
+	if conf.Method == "" {
+		conf.Method = "POST"
+	}
+	if conf.Endpoint == "" {
+		conf.Endpoint = "/"
+	}
+}
+
+func (d *driver) getBinaryPath(ctx context.Context, path string, conf *Config) (string, error) {
+	if conf.ExecutableConfig != nil {
+		return path, nil
+	}
+
+	builder := builder.New(filepath.Join(path, taskYmlPath))
+	return builder.Build(ctx)
 }

--- a/task/drivers/cgi/driver.go
+++ b/task/drivers/cgi/driver.go
@@ -27,6 +27,7 @@ type Config struct {
 	Endpoint         string                 `json:"endpoint"`
 	Headers          map[string]string      `json:"headers"`
 	Envs             []string               `json:"envs"`
+	Version          string                 `json:"version"`
 }
 
 // New returns the task execution driver.
@@ -51,7 +52,13 @@ func (d *driver) Handle(ctx context.Context, req *task.Request) task.Response {
 		return task.Error(err)
 	}
 
-	path, err := d.downloader.DownloadRepo(ctx, conf.Repository)
+	var path string
+	if conf.ExecutableConfig != nil {
+		path, err = d.downloader.DownloadExecutable(ctx, req.Task.Type, conf.Version, conf.ExecutableConfig)
+	} else {
+		path, err = d.downloader.DownloadRepo(ctx, conf.Repository)
+	}
+
 	if err != nil {
 		log.With("error", err).Error("artifact download failed")
 		return task.Error(err)


### PR DESCRIPTION
Previously, we always downloaded the repository specified in the config, and the binary path was incorrectly set to the repo. With this update, if an executable is specified, we skip downloading the repository and download the executable.