### PR TITLE
feat: [PIPE-22064]: Remove `version` field from CGI config

### DIFF
--- a/task/downloader/downloader.go
+++ b/task/downloader/downloader.go
@@ -37,6 +37,6 @@ func (d *Downloader) DownloadRepo(ctx context.Context, repo *task.Repository) (s
 	return d.repoDownloader.download(ctx, d.dir, repo)
 }
 
-func (d *Downloader) DownloadExecutable(ctx context.Context, taskType string, version string, exec *task.ExecutableConfig) (string, error) {
-	return d.executableDownloader.download(ctx, d.dir, taskType, version, exec)
+func (d *Downloader) DownloadExecutable(ctx context.Context, taskType string, exec *task.ExecutableConfig) (string, error) {
+	return d.executableDownloader.download(ctx, d.dir, taskType, exec)
 }

--- a/task/downloader/executable_downloader.go
+++ b/task/downloader/executable_downloader.go
@@ -31,7 +31,7 @@ func newExecutableDownloader() *executableDownloader {
 	return &executableDownloader{}
 }
 
-func (e *executableDownloader) download(ctx context.Context, dir string, taskType string, version string, exec *task.ExecutableConfig) (string, error) {
+func (e *executableDownloader) download(ctx context.Context, dir string, taskType string, exec *task.ExecutableConfig) (string, error) {
 	if exec == nil {
 		return "", errors.New("no executable urls provided to download")
 	}
@@ -42,7 +42,7 @@ func (e *executableDownloader) download(ctx context.Context, dir string, taskTyp
 		return "", fmt.Errorf("os [%s] and architecture [%s] are not specified in executable configuration", operatingSystem, architecture)
 	}
 
-	destDir := filepath.Join(dir, taskType, version)
+	destDir := filepath.Join(dir, taskType, getHash(url))
 	dest := getDownloadPath(url, destDir)
 
 	if cacheHit := isCacheHitFn(ctx, destDir); cacheHit {

--- a/task/downloader/executable_downloader_test.go
+++ b/task/downloader/executable_downloader_test.go
@@ -48,7 +48,6 @@ func TestDownloadExecutable(t *testing.T) {
 			name:     "successful_download",
 			dir:      "/tmp",
 			taskType: "binary",
-			version:  "v1.0.0",
 			exec: &task.ExecutableConfig{
 				Executables: []task.Executable{
 					{Os: runtime.GOOS, Arch: runtime.GOARCH, Url: "valid_url"},
@@ -61,7 +60,6 @@ func TestDownloadExecutable(t *testing.T) {
 			name:     "cache_hit",
 			dir:      "/tmp",
 			taskType: "binary",
-			version:  "v1.0.0",
 			exec: &task.ExecutableConfig{
 				Executables: []task.Executable{
 					{Os: runtime.GOOS, Arch: runtime.GOARCH, Url: "valid_url"},
@@ -74,7 +72,6 @@ func TestDownloadExecutable(t *testing.T) {
 			name:     "download_error",
 			dir:      "/tmp",
 			taskType: "binary",
-			version:  "v1.0.0",
 			exec: &task.ExecutableConfig{
 				Executables: []task.Executable{
 					{Os: runtime.GOOS, Arch: runtime.GOARCH, Url: "invalid_url"},
@@ -88,7 +85,6 @@ func TestDownloadExecutable(t *testing.T) {
 			name:     "chmod_error",
 			dir:      "/tmp",
 			taskType: "binary",
-			version:  "v1.0.0",
 			exec: &task.ExecutableConfig{
 				Executables: []task.Executable{
 					{Os: runtime.GOOS, Arch: runtime.GOARCH, Url: "valid_url"},
@@ -120,7 +116,7 @@ func TestDownloadExecutable(t *testing.T) {
 				return dest, nil
 			}
 
-			_, err := downloader.download(context.Background(), tt.dir, tt.taskType, tt.version, tt.exec)
+			_, err := downloader.download(context.Background(), tt.dir, tt.taskType, tt.exec)
 
 			if tt.wantErr {
 				assert.Error(t, err)

--- a/task/downloader/repo_downloader.go
+++ b/task/downloader/repo_downloader.go
@@ -6,8 +6,6 @@ package downloader
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -172,11 +170,5 @@ func (r *repoDownloader) getDownloadDir(dir string, repo *task.Repository) strin
 // whether it should be re-cloned.
 func (r *repoDownloader) getHashOfRepo(repo *task.Repository) string {
 	data := fmt.Sprintf("%s|%s|%s|%s", repo.Clone, repo.Ref, repo.Sha, repo.Download)
-	return r.getHash(data)
-}
-
-func (r *repoDownloader) getHash(s string) string {
-	hash := sha256.New()
-	hash.Write([]byte(s))
-	return hex.EncodeToString(hash.Sum(nil))
+	return getHash(data)
 }

--- a/task/downloader/util.go
+++ b/task/downloader/util.go
@@ -2,6 +2,8 @@ package downloader
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"net/http"
@@ -121,4 +123,10 @@ func SplitRef(s string) (string, string) {
 		u.RawFragment = ""
 		return u.String(), ref
 	}
+}
+
+func getHash(s string) string {
+	hash := sha256.New()
+	hash.Write([]byte(s))
+	return hex.EncodeToString(hash.Sum(nil))
 }

--- a/task/drivers/cgi/driver.go
+++ b/task/drivers/cgi/driver.go
@@ -27,7 +27,6 @@ type Config struct {
 	Endpoint         string                 `json:"endpoint"`
 	Headers          map[string]string      `json:"headers"`
 	Envs             []string               `json:"envs"`
-	Version          string                 `json:"version"`
 }
 
 // New returns the task execution driver.
@@ -76,7 +75,7 @@ func (d *driver) Handle(ctx context.Context, req *task.Request) task.Response {
 
 func (d *driver) downloadArtifact(ctx context.Context, taskType string, conf *Config) (string, error) {
 	if conf.ExecutableConfig != nil {
-		return d.downloader.DownloadExecutable(ctx, taskType, conf.Version, conf.ExecutableConfig)
+		return d.downloader.DownloadExecutable(ctx, taskType, conf.ExecutableConfig)
 	}
 	return d.downloader.DownloadRepo(ctx, conf.Repository)
 }


### PR DESCRIPTION
Since CGI tasks' versions are managed by the server which submits the tasks, we shouldn't need to pass the version to CGI's driver. The CGI driver only needs the URL to download the executable file.

In this PR, we remove the `version` field from CGI's config, and use the hash of executable's URL to create the path where the CGI executable is downloaded.