### PR TITLE
feat: [PIPE-24093]: Add SkipOpeningStream to Logger

### DIFF
--- a/task/types.go
+++ b/task/types.go
@@ -40,12 +40,13 @@ type Forward struct {
 // Logger provides instructions for logging the output
 // of a task execution.
 type Logger struct {
-	Address        string `json:"address"`
-	Insecure       bool   `json:"insecure"`
-	Token          string `json:"token"`
-	Key            string `json:"key"`
-	Account        string `json:"account"`
-	IndirectUpload bool   `json:"indirect_upload"`
+	Address           string `json:"address"`
+	Insecure          bool   `json:"insecure"`
+	Token             string `json:"token"`
+	Key               string `json:"key"`
+	Account           string `json:"account"`
+	IndirectUpload    bool   `json:"indirect_upload"`
+	SkipOpeningStream bool   `json:"skip_opening_stream"`
 }
 
 // Certs provides tls certificates.


### PR DESCRIPTION
Add the `SkipOpeningStream` field to Logger struct - this will be used in Runner (specifically, in lite-engine's livelog class) to decide whether a log-service stream should be opened or not. 

This is needed when some logs are sent during task scheduling phase by Harness server, in which case, if the stream is opened again by Runner, the previous logs get deleted.