### PR TITLE
fix: [PIPE-25194]: prefer prepackaged location

### DIFF
--- a/task/drivers/cgi/driver.go
+++ b/task/drivers/cgi/driver.go
@@ -79,10 +79,13 @@ func (d *driver) Handle(ctx context.Context, req *task.Request) task.Response {
 func (d *driver) prepareArtifact(ctx context.Context, taskType string, conf *Config) (string, error) {
 	// use binary artifact
 	if conf.ExecutableConfig != nil {
-		if shouldUsePrepackagedBinary(conf) {
-			return d.packageLoader.GetPackagePath(ctx, taskType, conf.ExecutableConfig)
-		} else {
+		cgiPath, err := d.packageLoader.GetPackagePath(ctx, taskType, conf.ExecutableConfig)
+		if err != nil {
 			return d.downloader.DownloadExecutable(ctx, taskType, conf.ExecutableConfig)
+		} else {
+			log := logger.FromContext(ctx)
+			log.WithField("path", cgiPath).Info("using prepackaged binary")
+			return cgiPath, nil
 		}
 	}
 	return d.downloader.DownloadRepo(ctx, conf.Repository)

--- a/task/packaged/packaged.go
+++ b/task/packaged/packaged.go
@@ -29,7 +29,14 @@ func New(dir string) PackageLoader {
 
 func (p *PackageLoader) GetPackagePath(ctx context.Context, taskType string, exec *task.ExecutableConfig) (string, error) {
 	dir := filepath.Join(p.dir, taskType, exec.Name)
-	return getFirstFile(dir)
+	if path, err := getFirstFile(dir); err == nil {
+		if chModErr := os.Chmod(path, 0777); chModErr != nil {
+			return "", fmt.Errorf("failed to set executable flag in task file [%s]: %w", path, err)
+		}
+		return path, nil
+	} else {
+		return "", err
+	}
 }
 
 func getFirstFile(directory string) (string, error) {

--- a/task/packaged/packaged.go
+++ b/task/packaged/packaged.go
@@ -47,5 +47,5 @@ func getFirstFile(directory string) (string, error) {
 	}
 
 	// If no files are found, return an error
-	return "", fmt.Errorf("no files found in directory: %s", directory)
+	return "", fmt.Errorf("no cgi found in directory: %s", directory)
 }


### PR DESCRIPTION
Currently, we use prepackaged cgi when the server doesn’t send any executable URLs to the runner.

But this doesn’t provide per-runner configuration ability, we can control at most at account level from the server side by using some feature flag

We need more flexibility and allow customers to control their runner’s behavior.

So change behavior to: runner will first look for prepackaged cgi, if not found, download

Test:
prepackaged working, ignore the connector test failure, the error is authentication error due to a bad token
<img width="1168" alt="image" src="https://github.com/user-attachments/assets/f042d9ce-8e7f-4712-afe0-75f3516c5889" />
<img width="581" alt="image" src="https://github.com/user-attachments/assets/7b44eb40-ab0f-44e3-8ffa-47da2300d74d" />


