### PR TITLE
fix: [PIPE-23883]: defined cgiTaskResponse, fix NPE error when pipeline execution and secret fetching fails

### DIFF
--- a/task/drivers/cgi/execer.go
+++ b/task/drivers/cgi/execer.go
@@ -6,6 +6,7 @@ package cgi
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"fmt"
 	"io"
 	"net/http"
@@ -83,7 +84,8 @@ func (e *Execer) Exec(ctx context.Context, in []byte) (*task.CGITaskResponse, er
 	}
 
 	log.Infof("Captured CGI logs: %s", stderrBuf.String())
-	return &task.CGITaskResponse{StatusCode: responseRecorder.Code, Body: responseRecorder.Body.Bytes(), Headers: headerToMap(responseRecorder.Header())}, nil
+	encodedBody := base64.StdEncoding.EncodeToString(responseRecorder.Body.Bytes())
+	return &task.CGITaskResponse{StatusCode: responseRecorder.Code, Body: encodedBody, Headers: headerToMap(responseRecorder.Header())}, nil
 }
 
 func headerToMap(header http.Header) map[string][]string {

--- a/task/router.go
+++ b/task/router.go
@@ -109,7 +109,7 @@ func (h *Router) ResolveSecrets(ctx context.Context, tasks []*Task) ([]*common.S
 		}
 
 		var secretOutputBytes []byte
-		if subtask.Driver != "cgi" && len(subtask.Config) == 0 {
+		if subtask.Driver != "cgi" && subtask.Type != "cgi" {
 			// This is not CGI task
 			secretOutputBytes = res.Body()
 		} else {

--- a/task/types.go
+++ b/task/types.go
@@ -84,6 +84,12 @@ type Executable struct {
 	Url  string `json:"url"`
 }
 
+type CGITaskResponse struct {
+	StatusCode int                 `json:"status_code"`
+	Headers    map[string][]string `json:"headers"`
+	Body       []byte              `json:"body"`
+}
+
 // type State struct {
 // 	// ID provides a unique task identifier.
 // 	ID string `json:"id"`

--- a/task/types.go
+++ b/task/types.go
@@ -87,7 +87,7 @@ type Executable struct {
 type CGITaskResponse struct {
 	StatusCode int                 `json:"status_code"`
 	Headers    map[string][]string `json:"headers"`
-	Body       []byte              `json:"body"`
+	Body       string              `json:"body"`  // base64 encoded
 }
 
 // type State struct {


### PR DESCRIPTION
1. Fix the NPE error when fetching secret fails during local_execute task. 
2. Defined CGITaskResponse type, so that it will be the standard CGI task response data structure. Using the status_code in it we can identify whether secret fetch succeeded or not. 