### PR TITLE
feat: [PIPE-26330]: Use RUN_AS_CGI=true environment variable for all CGI applications

### DIFF
--- a/task/drivers/cgi/driver.go
+++ b/task/drivers/cgi/driver.go
@@ -106,6 +106,12 @@ func setDefaultConfigValues(conf *Config) {
 	if conf.Endpoint == "" {
 		conf.Endpoint = "/"
 	}
+	// Always set RUN_AS_CGI=true for the CGI server process.
+	// In case the cgi's binary has other modes for running
+	// (like starting an HTTP or gRPC server) the cgi's application
+	// can use this environment variable to decide if it needs to
+	// start a CGI server.
+	conf.Envs = append(conf.Envs, "RUN_AS_CGI=true")
 }
 
 func (d *driver) getBinaryPath(ctx context.Context, path string, conf *Config) (string, error) {


### PR DESCRIPTION
Passing RUN_AS_CGI=true in env vars for all CGIs spawned by the cgi driver.